### PR TITLE
Add Next.js app-router sitemap and robots metadata routes

### DIFF
--- a/client/app/robots.ts
+++ b/client/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+
+import siteConfig from '@/constants/site-config';
+
+export default function robots(): MetadataRoute.Robots {
+	return {
+		rules: {
+			userAgent: '*',
+			allow: '/',
+		},
+		sitemap: new URL('/sitemap.xml', siteConfig.siteUrl).toString(),
+	};
+}

--- a/client/app/sitemap.ts
+++ b/client/app/sitemap.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from 'next';
+
+import siteConfig from '@/constants/site-config';
+
+const staticRoutes = [
+	'/',
+	'/about',
+	'/contact',
+	'/privacy',
+	'/project',
+	'/reports',
+	'/resources',
+	'/team',
+	'/terms',
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+	const lastModified = new Date();
+
+	return staticRoutes.map((route) => ({
+		url: new URL(route, siteConfig.siteUrl).toString(),
+		lastModified,
+	}));
+}


### PR DESCRIPTION
### Motivation

- Provide a generated `sitemap.xml` and `robots.txt` to improve SEO and crawler access.
- Use the Next.js app-router `MetadataRoute` APIs to emit the files at build time.
- Construct sitemap URLs from the canonical base URL in `client/constants/site-config.ts`.
- Include the static pages discovered under `client/app` so the sitemap reflects available routes.

### Description

- Add `client/app/sitemap.ts` which implements `MetadataRoute.Sitemap` and maps a `staticRoutes` array to absolute URLs using `siteConfig.siteUrl`.
- Add `client/app/robots.ts` which implements `MetadataRoute.Robots`, allows all user agents, and references the generated `/sitemap.xml`.
- The sitemap includes the routes: `/`, `/about`, `/contact`, `/privacy`, `/project`, `/reports`, `/resources`, `/team`, and `/terms`.
- Both files were added and committed to the repository.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd5cf9ce883328b023285063380a8)